### PR TITLE
netstandard build

### DIFF
--- a/ClickHouse.Ado/ClickHouse.Ado.NETStandard.csproj
+++ b/ClickHouse.Ado/ClickHouse.Ado.NETStandard.csproj
@@ -1,0 +1,53 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <Description>.NET driver for Yandex ClickHouse. It implements native ClickHouse protocol with data compression (not a wrapper for HTTP client)</Description>
+    <AssemblyTitle>ClickHouse.Ado</AssemblyTitle>
+    <VersionPrefix>1.0</VersionPrefix>
+    <Authors>Andrey Zakharov</Authors>
+	
+    <TargetFrameworks>netstandard1.5;net451</TargetFrameworks>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <AssemblyName>ClickHouse.Ado</AssemblyName>
+
+    <PackageId>ClickHouse.Ado</PackageId>
+    <PackageTags>ClickHouse;connector;ado.net;netstandard;netcore;net45</PackageTags>
+    <PackageProjectUrl>https://github.com/killwort/ClickHouse-Net</PackageProjectUrl>
+    <PackageLicenseUrl>https://github.com/killwort/ClickHouse-Net/blob/master/LICENSE</PackageLicenseUrl>
+    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.5' ">1.6.1</NetStandardImplicitPackageVersion>
+    <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
+    <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
+    <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
+    <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
+    <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
+    <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
+    <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
+    <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="lz4net" Version="1.0.15.93" />
+  </ItemGroup>
+  
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
+    <Reference Include="System.Data" />
+    <Reference Include="System" />
+  </ItemGroup>
+  
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net451' ">
+   	<PackageTargetFallback>$(PackageTargetFallback);net4-client</PackageTargetFallback>	 
+  </PropertyGroup>
+  
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.5' ">
+    <DefineConstants>$(DefineConstants);NETSTANDARD15</DefineConstants>
+  </PropertyGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.5' ">
+    <PackageReference Include="System.Data.Common" Version="4.3.0" />
+    <PackageReference Include="System.Reflection" Version="4.3.0" />
+	<PackageReference Include="System.Collections.NonGeneric" Version="4.3.0" />
+    <PackageReference Include="System.Reflection" Version="4.3.0" />
+    <PackageReference Include="System.Net.Sockets" Version="4.3.0" />	
+  </ItemGroup>
+
+</Project>

--- a/ClickHouse.Ado/ClickHouse.Ado.csproj
+++ b/ClickHouse.Ado/ClickHouse.Ado.csproj
@@ -114,13 +114,6 @@
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\ZstdNet.1.0.0\build\ZstdNet.targets" Condition="Exists('..\packages\ZstdNet.1.0.0\build\ZstdNet.targets')" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('..\packages\ZstdNet.1.0.0\build\ZstdNet.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\ZstdNet.1.0.0\build\ZstdNet.targets'))" />
-  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/ClickHouse.Ado/ClickHouseConnection.cs
+++ b/ClickHouse.Ado/ClickHouseConnection.cs
@@ -49,20 +49,28 @@ namespace ClickHouse.Ado
             }*/
             if (_stream != null)
             {
-                _stream.Close();
-                _stream.Dispose();
+#if !NETSTANDARD15
+				_stream.Close();
+#endif
+				_stream.Dispose();
                 _stream = null;
             }
             if (_netStream != null)
             {
-                _netStream.Close();
-                _netStream.Dispose();
+#if !NETSTANDARD15
+				_netStream.Close();
+#endif
+				_netStream.Dispose();
                 _netStream = null;
             }
             if (_tcpClient != null)
             {
-                _tcpClient.Close();
-                _tcpClient = null;
+#if !NETSTANDARD15
+				_tcpClient.Close();
+#else
+				_tcpClient.Dispose();
+#endif
+				_tcpClient = null;
             }
             if (Formatter != null)
             {
@@ -81,8 +89,12 @@ namespace ClickHouse.Ado
             //_tcpClient.NoDelay = true;
             _tcpClient.ReceiveBufferSize = ConnectionSettings.BufferSize;
             _tcpClient.SendBufferSize = ConnectionSettings.BufferSize;
-            _tcpClient.Connect(ConnectionSettings.Host, ConnectionSettings.Port);
-            _netStream = new NetworkStream(_tcpClient.Client);
+#if NETSTANDARD15
+			_tcpClient.ConnectAsync(ConnectionSettings.Host, ConnectionSettings.Port).RunSynchronously();
+#else
+			_tcpClient.Connect(ConnectionSettings.Host, ConnectionSettings.Port);
+#endif
+			_netStream = new NetworkStream(_tcpClient.Client);
             _stream =new UnclosableStream(_netStream);
             /*_reader=new BinaryReader(new UnclosableStream(_stream));
             _writer=new BinaryWriter(new UnclosableStream(_stream));*/

--- a/ClickHouse.Ado/ClickHouseConnectionSettings.cs
+++ b/ClickHouse.Ado/ClickHouseConnectionSettings.cs
@@ -12,8 +12,12 @@ namespace ClickHouse.Ado
 
         static ClickHouseConnectionSettings()
         {
-            Properties = typeof(ClickHouseConnectionSettings).GetProperties().ToDictionary(x => x.Name, x => x);
-        }
+#if NETSTANDARD15
+			Properties = typeof(ClickHouseConnectionSettings).GetTypeInfo().GetProperties().ToDictionary(x => x.Name, x => x);
+#else
+			Properties = typeof(ClickHouseConnectionSettings).GetProperties().ToDictionary(x => x.Name, x => x);
+#endif
+		}
         private void SetValue(string name, string value)
         {
             Properties[name].SetMethod.Invoke(this, new[] {Convert.ChangeType(value, Properties[name].PropertyType)});

--- a/ClickHouse.Ado/Impl/ATG/Enums/Scanner.cs
+++ b/ClickHouse.Ado/Impl/ATG/Enums/Scanner.cs
@@ -69,7 +69,11 @@ public class Buffer {
 	
 	protected void Close() {
 		if (!isUserStream && stream != null) {
+#if NETSTANDARD15
+			stream.Dispose();		
+#else
 			stream.Close();
+#endif
 			stream = null;
 		}
 	}

--- a/ClickHouse.Ado/Impl/ATG/IdentList/Scanner.cs
+++ b/ClickHouse.Ado/Impl/ATG/IdentList/Scanner.cs
@@ -69,8 +69,12 @@ public class Buffer {
 	
 	protected void Close() {
 		if (!isUserStream && stream != null) {
-			stream.Close();
-			stream = null;
+#if NETSTANDARD15
+				stream.Dispose();
+#else
+				stream.Close();
+#endif
+				stream = null;
 		}
 	}
 	

--- a/ClickHouse.Ado/Impl/ATG/Insert/Scanner.cs
+++ b/ClickHouse.Ado/Impl/ATG/Insert/Scanner.cs
@@ -69,8 +69,12 @@ public class Buffer {
 	
 	protected void Close() {
 		if (!isUserStream && stream != null) {
-			stream.Close();
-			stream = null;
+#if NETSTANDARD15
+				stream.Dispose();
+#else
+				stream.Close();
+#endif
+				stream = null;
 		}
 	}
 	

--- a/ClickHouse.Ado/Impl/ATG/Scanner.frame
+++ b/ClickHouse.Ado/Impl/ATG/Scanner.frame
@@ -95,7 +95,11 @@ internal class Buffer {
 	
 	protected void Close() {
 		if (!isUserStream && stream != null) {
+#if NETSTANDARD15
+			stream.Dispose();		
+#else
 			stream.Close();
+#endif
 			stream = null;
 		}
 	}

--- a/ClickHouse.Ado/Impl/ColumnTypes/NullableColumnType.cs
+++ b/ClickHouse.Ado/Impl/ColumnTypes/NullableColumnType.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections;
 using System.Data;
-using System.Data.SqlTypes;
 using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
@@ -60,8 +59,12 @@ namespace ClickHouse.Ado.Impl.ColumnTypes
         public override long IntValue(int currentRow)
         {
             if(Nulls[currentRow])
-                throw new SqlNullValueException();
-            return InnerType.IntValue(currentRow);
+#if NETSTANDARD15
+				throw new ArgumentNullException();
+#else
+				throw new System.Data.SqlTypes.SqlNullValueException();
+#endif
+			return InnerType.IntValue(currentRow);
         }
 
         public override void ValuesFromConst(IEnumerable objects)

--- a/ClickHouse.Ado/Impl/Data/ClientInfo.cs
+++ b/ClickHouse.Ado/Impl/Data/ClientInfo.cs
@@ -63,8 +63,10 @@ namespace ClickHouse.Ado.Impl.Data
 
         public void PopulateEnvironment()
         {
-            OsUser = Environment.UserName;
-            ClientHostname = Environment.MachineName;
+#if !NETSTANDARD15
+			OsUser = Environment.UserName;
+#endif
+			ClientHostname = Environment.MachineName;
         }
     }
 }

--- a/ClickHouse.Ado/Impl/UnclosableStream.cs
+++ b/ClickHouse.Ado/Impl/UnclosableStream.cs
@@ -8,10 +8,14 @@ namespace ClickHouse.Ado.Impl
     internal class UnclosableStream : Stream
     {
         private readonly Stream _baseStream;
-        public override void Close()
+
+#if !NETSTANDARD15
+		public override void Close()
         {
         }
-        public UnclosableStream(Stream baseStream)
+#endif
+
+		public UnclosableStream(Stream baseStream)
         {
             _baseStream = baseStream;
         }

--- a/ClickHouse.NETStandard.sln
+++ b/ClickHouse.NETStandard.sln
@@ -1,0 +1,22 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.26403.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ClickHouse.Ado.NETStandard", "ClickHouse.Ado\ClickHouse.Ado.NETStandard.csproj", "{A858251A-1B78-4AF8-A104-86ED711B1B07}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{A858251A-1B78-4AF8-A104-86ED711B1B07}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A858251A-1B78-4AF8-A104-86ED711B1B07}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A858251A-1B78-4AF8-A104-86ED711B1B07}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A858251A-1B78-4AF8-A104-86ED711B1B07}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
I've added new 'ClickHouse.Ado.NETStandard.csproj' (can be opened only by VS 2017)  that targets both netstandard1.5 and net451 in addition to existing 'ClickHouse.Ado.csproj' (still can be used with VS 2015).

With .NET SDK 1.0 it is possible to generate nuget package with both netstandard1.5 and net451 builds ( dotnet pack ClickHouse.Ado.NETStandard.csproj --configuration Release ).

Since 'SqlNullValueException' is not available in netstandard1.5 I've used ArgumentNullException.

