### PR TITLE
Throw invalidOperationException if connection isn't open

### DIFF
--- a/ClickHouse.Ado/ClickHouseCommand.cs
+++ b/ClickHouse.Ado/ClickHouseCommand.cs
@@ -71,6 +71,11 @@ namespace ClickHouse.Ado
 
         private void Execute(bool readResponse, ClickHouseConnection connection)
         {
+            if (connection.State != ConnectionState.Open)
+            {
+                throw new InvalidOperationException("Connection isn't open");
+            }
+            
             var insertParser = new Impl.ATG.Insert.Parser(new Impl.ATG.Insert.Scanner(new MemoryStream(Encoding.UTF8.GetBytes(CommandText))));
             insertParser.errors.errorStream=new StringWriter();
             insertParser.Parse();


### PR DESCRIPTION
Без этого, при попытке выполнить команду на закрытом подключении код выбрасывает nullReferenceException, что не слишком очевидно