### PR TITLE
Adding Nothing column type

### DIFF
--- a/ClickHouse.Ado/Impl/ColumnTypes/ColumnType.cs
+++ b/ClickHouse.Ado/Impl/ColumnTypes/ColumnType.cs
@@ -30,7 +30,8 @@ namespace ClickHouse.Ado.Impl.ColumnTypes
             {"Date", typeof(DateColumnType)},
             {"DateTime", typeof(DateTimeColumnType)},
             {"String", typeof(StringColumnType)},
-            {"Null", typeof(NullColumnType)}
+            {"Null", typeof(NullColumnType)},
+            {"Nothing", typeof(NullColumnType)}
         };
 
         internal abstract Type CLRType { get; }

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ rules however this is intentional.
 
 А ещё есть описание по-русски, см. ниже.
 
-## Imprortant usage notes
+## Important usage notes
 ### No multiple queries
 ClickHouse engine does not support parsing multiple queries per on `IDbCommand.Execute*` roundtrip. Please split your queries into separately executed commands.
 


### PR DESCRIPTION
Fixes #26 

Changes:
- Added `Nothing` column type to support recent versions of ClickHouse
- Fixed typo in README file