### PR TITLE
Allow string null as string column value

### DIFF
--- a/ClickHouse.Ado/ClickHouseCommand.cs
+++ b/ClickHouse.Ado/ClickHouseCommand.cs
@@ -98,7 +98,7 @@ namespace ClickHouse.Ado
                 if (insertParser.oneParam != null)
                 {
                     var table = ((IEnumerable)Parameters[insertParser.oneParam].Value).OfType<IEnumerable>();
-                    var colCount = table.First().OfType<object>().Count();
+                    var colCount = table.First().Cast<object>().Count();
                     if (colCount != schema.Columns.Count)
                         throw new FormatException($"Column count in parameter table ({colCount}) doesn't match column count in schema ({schema.Columns.Count}).");
                     var cl = new List<List<object>>(colCount);

--- a/ClickHouse.Ado/Impl/ColumnTypes/ArrayColumnType.cs
+++ b/ClickHouse.Ado/Impl/ColumnTypes/ArrayColumnType.cs
@@ -81,12 +81,18 @@ namespace ClickHouse.Ado.Impl.ColumnTypes
             var offsets = new List<ulong>();
             var itemsPlain = new List<object>();
             ulong currentOffset = 0;
-            foreach (var item in objects.Cast<IEnumerable<object>>())
+            foreach (var item in objects)
             {
-                currentOffset += (ulong)item.Count();
+                ulong itemCount = 0;
+                foreach (var itemPart in item)
+                {
+                    itemCount++;
+                    itemsPlain.AddRange(itemPart);
+                }
+                currentOffset += itemCount;
                 offsets.Add(currentOffset);
-                itemsPlain.AddRange(item);
             }
+            
             Offsets.ValuesFromConst(offsets);
             InnerType.ValuesFromConst(itemsPlain);
         }

--- a/ClickHouse.Ado/Impl/ColumnTypes/ArrayColumnType.cs
+++ b/ClickHouse.Ado/Impl/ColumnTypes/ArrayColumnType.cs
@@ -84,10 +84,10 @@ namespace ClickHouse.Ado.Impl.ColumnTypes
             foreach (var item in objects)
             {
                 ulong itemCount = 0;
-                foreach (var itemPart in item)
+                foreach (var itemPart in (IEnumerable)item)
                 {
                     itemCount++;
-                    itemsPlain.AddRange(itemPart);
+                    itemsPlain.Add(itemPart);
                 }
                 currentOffset += itemCount;
                 offsets.Add(currentOffset);


### PR DESCRIPTION
Fixes #51 and #54

Changes:
-OfType -> Cast
ArrayColumnType.ValuesFromConst casting change (IEnumerable.Cast sucks)
