### PR TITLE
Add target framework netstandart2.0.

### DIFF
--- a/ClickHouse.Ado/ClickHouse.Ado.NETStandard.csproj
+++ b/ClickHouse.Ado/ClickHouse.Ado.NETStandard.csproj
@@ -6,7 +6,7 @@
     <VersionPrefix>1.2.1</VersionPrefix>
     <Authors>Andrey Zakharov</Authors>
 	
-    <TargetFrameworks>net461;netstandard1.5</TargetFrameworks>
+    <TargetFrameworks>net461;netstandard1.5;netstandard2.0</TargetFrameworks>
 <!--    <TargetFramework>net451</TargetFramework>-->
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>ClickHouse.Ado</AssemblyName>
@@ -36,7 +36,6 @@ del /q $(SolutionDir).lock
   <ItemGroup Condition=" '$(TargetFramework)' == 'net461' or '$(TargetFramework)' == 'net45' or '$(TargetFramework)' == 'net40' or '$(TargetFramework)' == 'net20' ">
     <Reference Include="System.Data" />
     <Reference Include="System" />
-    <PackageReference Include="lz4net" Version="1.0.15.93" />
   </ItemGroup>
   
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net461' or '$(TargetFramework)' == 'net45' or '$(TargetFramework)' == 'net40' or '$(TargetFramework)' == 'net20' ">
@@ -78,7 +77,6 @@ del /q $(SolutionDir).lock
     <PackageReference Include="System.Collections.NonGeneric" Version="4.3.0" />
     <PackageReference Include="System.Reflection" Version="4.3.0" />
     <PackageReference Include="System.Net.Sockets" Version="4.3.0" />	-->
-    <PackageReference Include="lz4net" Version="1.0.15.93" />
 
   </ItemGroup>
 
@@ -93,5 +91,9 @@ del /q $(SolutionDir).lock
     <PackageReference Include="System.Threading.Thread">
       <Version>4.3.0</Version>
     </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="lz4net" Version="1.0.15.93" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
(for using sync tcpClient.Connect() if .net core version > 1.1

Fixes #
Fix blocking call of TcpClient.Connect() if target framework > net.core 1.1. Without target framework netstandart 2.0, 
predefined condition https://github.com/killwort/ClickHouse-Net/blob/master/ClickHouse.Ado/ClickHouseConnection.cs#L92 always compilied as `#elif NETSTANDARD15` branch, even if the target project (which uses the library) used newer vesion of target framework.
Changes:
-
-
-
