### PR TITLE
Dapper throw exception

### DIFF
--- a/ClickHouse.Ado/Impl/ColumnTypes/ArrayColumnType.cs
+++ b/ClickHouse.Ado/Impl/ColumnTypes/ArrayColumnType.cs
@@ -60,9 +60,9 @@ namespace ClickHouse.Ado.Impl.ColumnTypes {
         public override object Value(int currentRow) {
             var start = currentRow == 0 ? 0 : Offsets.Data[currentRow - 1];
             var end = Offsets.Data[currentRow];
-            var rv = new object[end - start];
+            var rv = Array.CreateInstance(InnerType.CLRType, (int)(end - start));
             for (var i = start; i < end; i++)
-                rv[i - start] = InnerType.Value((int) i);
+                rv.SetValue(InnerType.Value((int)i), (int)(i - start));
             return rv;
         }
 


### PR DESCRIPTION
Dapper throw exception:
System.InvalidCastException: Unable to cast object of type 'System.Object[]' to type 'System.UInt32[]'.

Fixes #

Changes:
-
-
-
