### PR TITLE
fix NullableColumnType bug

### DIFF
--- a/ClickHouse.Ado/Impl/ColumnTypes/NullableColumnType.cs
+++ b/ClickHouse.Ado/Impl/ColumnTypes/NullableColumnType.cs
@@ -11,7 +11,7 @@ namespace ClickHouse.Ado.Impl.ColumnTypes {
 
         public override bool IsNullable => true;
         public override int Rows => InnerType.Rows;
-        internal override Type CLRType => InnerType.CLRType.IsByRef ? InnerType.CLRType : typeof(Nullable<>).MakeGenericType(InnerType.CLRType);
+        internal override Type CLRType => !InnerType.CLRType.IsByRef ? InnerType.CLRType : typeof(Nullable<>).MakeGenericType(InnerType.CLRType);
 
         public ColumnType InnerType { get; }
         public bool[] Nulls { get; private set; }


### PR DESCRIPTION
Fixes #
fix https://github.com/killwort/ClickHouse-Net/issues/122
Changes:
internal override Type CLRType => !InnerType.CLRType.IsByRef ? InnerType.CLRType : typeof(Nullable<>).MakeGenericType(InnerType.CLRType);
