### PR TITLE
Fix null reference in EndConnect() when connection is lost

### DIFF
--- a/ClickHouse.Ado/ClickHouseConnection.cs
+++ b/ClickHouse.Ado/ClickHouseConnection.cs
@@ -81,7 +81,9 @@ namespace ClickHouse.Ado {
             } catch {
             }
 
-            if (state.Client.Connected && state.Success)
+            var isConnected = state.Client?.Client != null ? state.Client.Connected : false;
+
+            if (isConnected && state.Success)
                 return;
 
             state.Client.Close();


### PR DESCRIPTION
Fix TcpClient.Connect exception in EndConnect() when connection is lost midway

Fixes #

We have a client with multiple connections to a ClickHouse database. We were having exceptions in the EndConnect() method in ClickHouseConnection when the database connection is lost due to internet issues. This is due to _tcpClient.Client being null.

Changes:
- Added null check when getting connection state
