### PR TITLE
Select exception bug fix

### DIFF
--- a/ClickHouse.Ado/ClickHouseDataReader.cs
+++ b/ClickHouse.Ado/ClickHouseDataReader.cs
@@ -114,7 +114,16 @@ namespace ClickHouse.Ado {
 
         public bool NextResult() {
             _currentRow = -1;
-            return (_currentBlock = _clickHouseConnection.Formatter.ReadBlock()) != null;
+
+            try
+            {
+                _currentBlock = _clickHouseConnection.Formatter.ReadBlock();
+            }
+            catch (Exception ex) {
+                _currentBlock = null;
+                throw;
+            }
+            return _currentBlock != null;
         }
 
         public bool Read() {

--- a/ClickHouse.Test/ClickHouse.Test.csproj
+++ b/ClickHouse.Test/ClickHouse.Test.csproj
@@ -61,6 +61,7 @@
     <Compile Include="ConnectionHandler.cs" />
     <Compile Include="SimpleTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="TestExceptions.cs" />
     <Compile Include="TestArraySupport.cs" />
     <Compile Include="TestDate32Support.cs" />
     <Compile Include="TestDateTime64Support.cs" />

--- a/ClickHouse.Test/TestExceptions.cs
+++ b/ClickHouse.Test/TestExceptions.cs
@@ -1,0 +1,34 @@
+﻿using System.Collections.Generic;
+using System.Data;
+using System.Linq;
+using ClickHouse.Ado;
+using NUnit.Framework;
+
+namespace ClickHouse.Test
+{
+    [TestFixture]
+    public class TestExceptions
+    {
+        [Test, Timeout(5000)]
+        public void TestSelectWithMemoryLimitException()
+        {
+            using (var cnn = ConnectionHandler.GetConnection())
+            {
+                cnn.CreateCommand("SET max_memory_usage = 3000").ExecuteNonQuery();
+
+                Assert.Throws<ClickHouseException>(() =>
+                {
+                    var data = ReadRawData(cnn.CreateCommand("SELECT groupArray(number) FROM system.numbers LIMIT 1000000000")).ToList();
+                });
+            }      
+        }
+
+        private IEnumerable<IDataRecord> ReadRawData(ClickHouseCommand command)
+        {
+            using (var reader = command.ExecuteReader())
+                while (reader.NextResult())
+                    while (reader.Read())
+                        yield return reader;
+        }
+    }
+}


### PR DESCRIPTION
В ходе тестирования выявили проблему. Если в при запросе на select мы ловим exception(например memory limit), то драйвер повисает и через час отваливается с ошибкой Connection isn't open.
